### PR TITLE
fix: timeout accepts decimal(float) values and fixed bug with args parsing

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -131,7 +131,7 @@ the special character '!' execute system's commands:
     -rwxrwx--- 1 root vboxsf  2115 lug  2 08:57 tests.py
 
 
-All commands have 1 seconds timeout as default, but that can be changed with `set_timeout` command. If a command does not return, stop it with CTRL-B or CTRL-C
+All commands have 1.0 seconds timeout as default, but that can be changed with `set_timeout` command. If a command does not return, stop it with CTRL-B or CTRL-C
 
 
 Highlight patterns

--- a/src/pynicom.py
+++ b/src/pynicom.py
@@ -109,7 +109,7 @@ class Pynicom(Cmd):
 
         where the args are respectively: port, baudrate, bytesize, parity, stopbits, SW flow control, HW flow control RTS/CTS, HW flow control DSR/DTR, timeout
         """
-       
+
         for id, arg in enumerate(string.split(' ')):
             if arg == '':
                 continue

--- a/src/pynicom.py
+++ b/src/pynicom.py
@@ -55,7 +55,7 @@ class Pynicom(Cmd):
     _port_config = {
             'port':'/dev/ttyUSB0', 'baudrate':115200, 'bytesize':8,
             'parity':'N', 'stopbits':1, 'xonxoff':False,
-            'rtscts':False, 'dsrdtr':False, 'timeout':1
+            'rtscts':False, 'dsrdtr':False, 'timeout':1.0
             }
 
     def do_dictionary(self, string = None):
@@ -109,8 +109,10 @@ class Pynicom(Cmd):
 
         where the args are respectively: port, baudrate, bytesize, parity, stopbits, SW flow control, HW flow control RTS/CTS, HW flow control DSR/DTR, timeout
         """
-
+       
         for id, arg in enumerate(string.split(' ')):
+            if arg == '':
+                continue
             if 0 == id:
                 self._port_config ['port'] = arg
             if 1 == id:
@@ -128,7 +130,7 @@ class Pynicom(Cmd):
             if 7 == id:
                 self._port_config ['dsrdtr'] = eval(arg)
             if 8 == id:
-                self._port_config ['timeout'] = int(arg)
+                self._port_config ['timeout'] = float(arg)
 
         logd('Connecting with the following params {0}.'.format(self._port_config))
 
@@ -234,7 +236,7 @@ class Pynicom(Cmd):
     def do_set_timeout(self, string):
         """Set serial connection timeout"""
         if self.__is_valid_connection():
-            self.connection.timeout = int(string)
+            self.connection.timeout = float(string)
 
     def do_serial_read(self, mode = ''):
         """Read from serial device. Press CTRL-C to interrupt it.
@@ -335,7 +337,7 @@ class Pynicom(Cmd):
             self._port_config = {
                     'port':'/dev/ttyUSB0', 'baudrate':115200, 'bytesize':8,
                     'parity':'N', 'stopbits':1, 'xonxoff':False,
-                    'rtscts':False, 'dsrdtr':False, 'timeout':1
+                    'rtscts':False, 'dsrdtr':False, 'timeout':1.0
                     }
             logi('connection closed')
 
@@ -601,20 +603,36 @@ def init(arguments = {}):
         connect_at_init += (arguments ['--port'])
     if arguments ['--baud']:
         connect_at_init += (' ' + arguments ['--baud'] )
+    else:
+        connect_at_init +=(' ')
     if arguments ['--bytesize']:
         connect_at_init += (' ' + arguments ['--bytesize'] )
+    else:
+        connect_at_init +=(' ')        
     if arguments ['--parity']:
         connect_at_init += (' ' + arguments ['--parity'] )
+    else:
+        connect_at_init +=(' ')        
     if arguments ['--stopbits']:
         connect_at_init += (' ' + arguments ['--stopbits'] )
+    else:
+        connect_at_init +=(' ')        
     if arguments ['--sw-flow-ctrl']:
         connect_at_init += (' ' + arguments ['--sw-flow-ctrl'] )
+    else:
+        connect_at_init +=(' ')        
     if arguments ['--hw-rts-cts']:
         connect_at_init += (' ' + arguments ['--hw-rts-cts'] )
+    else:
+        connect_at_init +=(' ')        
     if arguments ['--hw-dsr-dtr']:
         connect_at_init += (' ' + arguments ['--hw-dsr-dtr'] )
+    else:
+        connect_at_init +=(' ')        
     if arguments ['--timeout']:
         connect_at_init += (' ' + arguments ['--timeout'] )
+    else:
+        connect_at_init +=(' ')        
 
     if 0 < len(connect_at_init):
         shell.do_serial_open(connect_at_init)


### PR DESCRIPTION
pyserial accepts timeout in float, so timeout lower than 1 s can be used

In init() (line 577), connect_at_init doesn't take care of args if they are not passed.
so, In do_serial_open() for loop used with enumeration (line 113) fails to distinguish between args and arg mismatch happens if any args after baud rate in the sequence is not passed initially and fials to open the serial connection.
//fixed it with minimum changes possible